### PR TITLE
Removed breaking migration while retaining valid field creation

### DIFF
--- a/knox/migrations/0005_authtoken_token_key.py
+++ b/knox/migrations/0005_authtoken_token_key.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='authtoken',
             name='token_key',
-            field=models.CharField(blank=True, db_index=True, max_length=8, null=True),
+            field=models.CharField(db_index=True, default='', max_length=8),
+            preserve_default=False,
         ),
     ]

--- a/knox/migrations/0006_auto_20160818_0932.py
+++ b/knox/migrations/0006_auto_20160818_0932.py
@@ -5,11 +5,6 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 
-def cleanup_tokens(apps, schema_editor):
-    AuthToken = apps.get_model('knox', 'AuthToken')
-    AuthToken.objects.filter(token_key__isnull=True).delete()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -17,11 +12,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(cleanup_tokens),
-        migrations.AlterField(
-            model_name='authtoken',
-            name='token_key',
-            field=models.CharField(db_index=True, default='', max_length=8),
-            preserve_default=False,
-        ),
     ]


### PR DESCRIPTION
James' migration `0006` is actually incompatible with postgres as it updates data in a model and then alters the field, causing the following issue:

```
Running migrations:
  Applying auth.0008_alter_user_username_max_length... OK
  Applying knox.0005_authtoken_token_key... OK
  Applying knox.0006_auto_20160818_0932...Traceback (most recent call last):
...
django.db.utils.OperationalError: cannot ALTER TABLE "knox_authtoken" because it has pending trigger event
```
Since we are running `0005` and `0006` together, we can simply create the correct field with `0005` and leave `0006` as a no-op.