### PR TITLE
Backport changes to switch require from pyOpenSSL to cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['django', 'djangorestframework', 'pyOpenSSL'],
+    install_requires=['django', 'djangorestframework', 'cryptography'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     djangorestframework
     freezegun
     mkdocs
-    pyOpenSSL
+    cryptography
     pytest-django
     setuptools
     twine


### PR DESCRIPTION
This brings in the changes from the recently merged PR upstream